### PR TITLE
3.4.0 stat compatibility and dashboard robustness while zk's are restarting

### DIFF
--- a/zkadmin/models.py
+++ b/zkadmin/models.py
@@ -42,7 +42,6 @@ class ZKServer(object):
         for line in sio:
             attr, value = line.split(':')
             attr = attr.strip().replace(" ", "_").replace("/", "_").lower()
-            print attr
             self.__dict__[attr] = value.strip()
 
         self.min_latency, self.avg_latency, self.max_latency = self.latency_min_avg_max.split("/")

--- a/zkadmin/models.py
+++ b/zkadmin/models.py
@@ -9,7 +9,7 @@ OP_ACCEPT = 16
 
 class Session(object):
     def __init__(self, session):
-        m = re.search('/(\d+\.\d+\.\d+\.\d+):(\d+)\[(\d+)\]\((.*)\)', session)
+    	m = re.search('/(\d+\.\d+\.\d+\.\d+):(\d+)\[(\d+)\]\((.*)', session)
         self.host = m.group(1)
         self.port = m.group(2)
         self.interest_ops = m.group(3)
@@ -36,12 +36,13 @@ class ZKServer(object):
         sio.readline()
         self.sessions = []
         for line in sio:
-            if not line.strip():
-                break
-            self.sessions.append(Session(line.strip()))
+            if line.startswith('/', 1, 2):
+               self.sessions.append(Session(line.strip()))
+               break
         for line in sio:
             attr, value = line.split(':')
             attr = attr.strip().replace(" ", "_").replace("/", "_").lower()
+            print attr
             self.__dict__[attr] = value.strip()
 
         self.min_latency, self.avg_latency, self.max_latency = self.latency_min_avg_max.split("/")

--- a/zkadmin/models.py
+++ b/zkadmin/models.py
@@ -32,7 +32,11 @@ class ZKServer(object):
         sio = StringIO.StringIO(stat)
         line = sio.readline()
         m = re.search('.*: (\d+\.\d+\.\d+)-.*', line)
-        self.version = m.group(1)
+        try:
+            self.version = m.group(1)
+        except:
+            self.version = 'Not available'
+        
         sio.readline()
         self.sessions = []
         for line in sio:
@@ -44,8 +48,11 @@ class ZKServer(object):
             attr = attr.strip().replace(" ", "_").replace("/", "_").lower()
             self.__dict__[attr] = value.strip()
 
-        self.min_latency, self.avg_latency, self.max_latency = self.latency_min_avg_max.split("/")
-
+        try:
+            self.min_latency, self.avg_latency, self.max_latency = self.latency_min_avg_max.split("/")
+        except:
+		    self.min_latency, self.avg_latency, self.max_latency = 0,0,0
+		
         self.envi = []
         sio = StringIO.StringIO(envi)
         for line in sio:


### PR DESCRIPTION
for 3.4.0 the stat command returns clients without the closing ) modified models.py to account for this fact. 

added try/except clauses for various property assignment code with simple defaults so the dashboard won't crash with an error when one of the zookeepers in the ensemble is restarting (versions/latencies were not resolving correctly)
